### PR TITLE
MAINT add explicit dependncy on certifi

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,11 @@
 # CHANGELOG
 
+## 0.9.7
+
+  - Add explicit dependency on certifi to resolve SSL
+    verification issues on appveyor.
+    https://github.com/ogrisel/wheelhouse-uploader/issues/26
+
 ## 0.9.5 - 2017-04-26
 
   - Pin dependency apache-libcloud==1.1.0 to workaround

--- a/setup.py
+++ b/setup.py
@@ -27,6 +27,7 @@ setup(
     install_requires=[
         "setuptools>=0.9",  # required for PEP 440 version parsing
         "packaging",
+        "certifi",
         'futures; python_version == "2.7"',
         "apache-libcloud==1.1.0",
     ],


### PR DESCRIPTION
As reported in #26, the default certificates available on appveyor are no longer enough to securely talk to rackspace. 