### PR TITLE
Support PyPy tags

### DIFF
--- a/wheelhouse_uploader/utils.py
+++ b/wheelhouse_uploader/utils.py
@@ -122,7 +122,7 @@ def _parse_wheel_filename(basename, project_name=None, return_tags=False):
         pyversion = '.'.join(str(x) for x in sys.version_info[:2])
     elif pytag[:2] == 'py' and len(pytag) == 3:
         pyversion = '%s' % pytag[2]
-    elif pytag[:2] == 'py' and len(pytag) == 4:
+    elif pytag[:2] in ['pp', 'py'] and len(pytag) == 4:
         pyversion = '%s.%s' % (pytag[2], pytag[3])
     elif pytag[:2] == 'cp':
         pyversion = '%s.%s' % (pytag[2], pytag[3])


### PR DESCRIPTION
We recently added PyPy3 wheels to Pillow, but wheelhouse-uploader failed to upload them:

- Skipping Pillow-7.2.0-pp36-pypy36_pp73-macosx_10_10_x86_64.whl: Invalid or unsupported Python version tag in filename Pillow-7.2.0-pp36-pypy36_pp73-macosx_10_10_x86_64.whl - https://travis-ci.org/github/python-pillow/pillow-wheels/jobs/703441814#L5518
- Skipping Pillow-7.2.0-pp36-pypy36_pp73-manylinux2010_x86_64.whl: Invalid or unsupported Python version tag in filename Pillow-7.2.0-pp36-pypy36_pp73-manylinux2010_x86_64.whl - https://travis-ci.org/github/python-pillow/pillow-wheels/jobs/703441815#L6132

Looks like wheelhouse-uploader doesn't support PyPy tags:

https://github.com/ogrisel/wheelhouse-uploader/blob/01ee128247a2284813c84ab9d8cd48105f2d9e06/wheelhouse_uploader/utils.py#L120-L131

Re: https://github.com/python-pillow/Pillow/issues/4658#issuecomment-651716419, https://github.com/python-pillow/Pillow/issues/4658#issuecomment-651720210

---

# Test script

```python
from wheelhouse_uploader import utils

filenames = [
    "Pillow-7.2.0-cp35-cp35m-macosx_10_10_intel.whl",
    "Pillow-7.2.0-cp35-cp35m-manylinux1_i686.whl",
    "Pillow-7.2.0-cp35-cp35m-manylinux1_x86_64.whl",
    "Pillow-7.2.0-cp35-cp35m-manylinux2014_aarch64.whl",
    "Pillow-7.2.0-cp35-cp35m-win32.whl",
    "Pillow-7.2.0-cp35-cp35m-win_amd64.whl",
    "Pillow-7.2.0-cp36-cp36m-macosx_10_10_x86_64.whl",
    "Pillow-7.2.0-cp36-cp36m-manylinux1_i686.whl",
    "Pillow-7.2.0-cp36-cp36m-manylinux1_x86_64.whl",
    "Pillow-7.2.0-cp36-cp36m-manylinux2014_aarch64.whl",
    "Pillow-7.2.0-cp36-cp36m-win32.whl",
    "Pillow-7.2.0-cp36-cp36m-win_amd64.whl",
    "Pillow-7.2.0-cp37-cp37m-macosx_10_10_x86_64.whl",
    "Pillow-7.2.0-cp37-cp37m-manylinux1_i686.whl",
    "Pillow-7.2.0-cp37-cp37m-manylinux1_x86_64.whl",
    "Pillow-7.2.0-cp37-cp37m-manylinux2014_aarch64.whl",
    "Pillow-7.2.0-cp37-cp37m-win32.whl",
    "Pillow-7.2.0-cp37-cp37m-win_amd64.whl",
    "Pillow-7.2.0-cp38-cp38-macosx_10_10_x86_64.whl",
    "Pillow-7.2.0-cp38-cp38-manylinux1_i686.whl",
    "Pillow-7.2.0-cp38-cp38-manylinux1_x86_64.whl",
    "Pillow-7.2.0-cp38-cp38-manylinux2014_aarch64.whl",
    "Pillow-7.2.0-cp38-cp38-win32.whl",
    "Pillow-7.2.0-cp38-cp38-win_amd64.whl",
    "Pillow-7.2.0-pp36-pypy36_pp73-win32.whl",
    "Pillow-7.2.0-pp36-pypy36_pp73-manylinux2010_x86_64.whl",
]


for filename in filenames:
    try:
        print(utils.parse_filename(filename), filename)
    except:
        print("nope", filename)
```

# Before

```
('Pillow', '7.2.0', '3.5', 'bdist_wheel') Pillow-7.2.0-cp35-cp35m-macosx_10_10_intel.whl
('Pillow', '7.2.0', '3.5', 'bdist_wheel') Pillow-7.2.0-cp35-cp35m-manylinux1_i686.whl
('Pillow', '7.2.0', '3.5', 'bdist_wheel') Pillow-7.2.0-cp35-cp35m-manylinux1_x86_64.whl
('Pillow', '7.2.0', '3.5', 'bdist_wheel') Pillow-7.2.0-cp35-cp35m-manylinux2014_aarch64.whl
('Pillow', '7.2.0', '3.5', 'bdist_wheel') Pillow-7.2.0-cp35-cp35m-win32.whl
('Pillow', '7.2.0', '3.5', 'bdist_wheel') Pillow-7.2.0-cp35-cp35m-win_amd64.whl
('Pillow', '7.2.0', '3.6', 'bdist_wheel') Pillow-7.2.0-cp36-cp36m-macosx_10_10_x86_64.whl
('Pillow', '7.2.0', '3.6', 'bdist_wheel') Pillow-7.2.0-cp36-cp36m-manylinux1_i686.whl
('Pillow', '7.2.0', '3.6', 'bdist_wheel') Pillow-7.2.0-cp36-cp36m-manylinux1_x86_64.whl
('Pillow', '7.2.0', '3.6', 'bdist_wheel') Pillow-7.2.0-cp36-cp36m-manylinux2014_aarch64.whl
('Pillow', '7.2.0', '3.6', 'bdist_wheel') Pillow-7.2.0-cp36-cp36m-win32.whl
('Pillow', '7.2.0', '3.6', 'bdist_wheel') Pillow-7.2.0-cp36-cp36m-win_amd64.whl
('Pillow', '7.2.0', '3.7', 'bdist_wheel') Pillow-7.2.0-cp37-cp37m-macosx_10_10_x86_64.whl
('Pillow', '7.2.0', '3.7', 'bdist_wheel') Pillow-7.2.0-cp37-cp37m-manylinux1_i686.whl
('Pillow', '7.2.0', '3.7', 'bdist_wheel') Pillow-7.2.0-cp37-cp37m-manylinux1_x86_64.whl
('Pillow', '7.2.0', '3.7', 'bdist_wheel') Pillow-7.2.0-cp37-cp37m-manylinux2014_aarch64.whl
('Pillow', '7.2.0', '3.7', 'bdist_wheel') Pillow-7.2.0-cp37-cp37m-win32.whl
('Pillow', '7.2.0', '3.7', 'bdist_wheel') Pillow-7.2.0-cp37-cp37m-win_amd64.whl
('Pillow', '7.2.0', '3.8', 'bdist_wheel') Pillow-7.2.0-cp38-cp38-macosx_10_10_x86_64.whl
('Pillow', '7.2.0', '3.8', 'bdist_wheel') Pillow-7.2.0-cp38-cp38-manylinux1_i686.whl
('Pillow', '7.2.0', '3.8', 'bdist_wheel') Pillow-7.2.0-cp38-cp38-manylinux1_x86_64.whl
('Pillow', '7.2.0', '3.8', 'bdist_wheel') Pillow-7.2.0-cp38-cp38-manylinux2014_aarch64.whl
('Pillow', '7.2.0', '3.8', 'bdist_wheel') Pillow-7.2.0-cp38-cp38-win32.whl
('Pillow', '7.2.0', '3.8', 'bdist_wheel') Pillow-7.2.0-cp38-cp38-win_amd64.whl
nope Pillow-7.2.0-pp36-pypy36_pp73-win32.whl
nope Pillow-7.2.0-pp36-pypy36_pp73-manylinux2010_x86_64.whl
```

# After

```
('Pillow', '7.2.0', '3.5', 'bdist_wheel') Pillow-7.2.0-cp35-cp35m-macosx_10_10_intel.whl
('Pillow', '7.2.0', '3.5', 'bdist_wheel') Pillow-7.2.0-cp35-cp35m-manylinux1_i686.whl
('Pillow', '7.2.0', '3.5', 'bdist_wheel') Pillow-7.2.0-cp35-cp35m-manylinux1_x86_64.whl
('Pillow', '7.2.0', '3.5', 'bdist_wheel') Pillow-7.2.0-cp35-cp35m-manylinux2014_aarch64.whl
('Pillow', '7.2.0', '3.5', 'bdist_wheel') Pillow-7.2.0-cp35-cp35m-win32.whl
('Pillow', '7.2.0', '3.5', 'bdist_wheel') Pillow-7.2.0-cp35-cp35m-win_amd64.whl
('Pillow', '7.2.0', '3.6', 'bdist_wheel') Pillow-7.2.0-cp36-cp36m-macosx_10_10_x86_64.whl
('Pillow', '7.2.0', '3.6', 'bdist_wheel') Pillow-7.2.0-cp36-cp36m-manylinux1_i686.whl
('Pillow', '7.2.0', '3.6', 'bdist_wheel') Pillow-7.2.0-cp36-cp36m-manylinux1_x86_64.whl
('Pillow', '7.2.0', '3.6', 'bdist_wheel') Pillow-7.2.0-cp36-cp36m-manylinux2014_aarch64.whl
('Pillow', '7.2.0', '3.6', 'bdist_wheel') Pillow-7.2.0-cp36-cp36m-win32.whl
('Pillow', '7.2.0', '3.6', 'bdist_wheel') Pillow-7.2.0-cp36-cp36m-win_amd64.whl
('Pillow', '7.2.0', '3.7', 'bdist_wheel') Pillow-7.2.0-cp37-cp37m-macosx_10_10_x86_64.whl
('Pillow', '7.2.0', '3.7', 'bdist_wheel') Pillow-7.2.0-cp37-cp37m-manylinux1_i686.whl
('Pillow', '7.2.0', '3.7', 'bdist_wheel') Pillow-7.2.0-cp37-cp37m-manylinux1_x86_64.whl
('Pillow', '7.2.0', '3.7', 'bdist_wheel') Pillow-7.2.0-cp37-cp37m-manylinux2014_aarch64.whl
('Pillow', '7.2.0', '3.7', 'bdist_wheel') Pillow-7.2.0-cp37-cp37m-win32.whl
('Pillow', '7.2.0', '3.7', 'bdist_wheel') Pillow-7.2.0-cp37-cp37m-win_amd64.whl
('Pillow', '7.2.0', '3.8', 'bdist_wheel') Pillow-7.2.0-cp38-cp38-macosx_10_10_x86_64.whl
('Pillow', '7.2.0', '3.8', 'bdist_wheel') Pillow-7.2.0-cp38-cp38-manylinux1_i686.whl
('Pillow', '7.2.0', '3.8', 'bdist_wheel') Pillow-7.2.0-cp38-cp38-manylinux1_x86_64.whl
('Pillow', '7.2.0', '3.8', 'bdist_wheel') Pillow-7.2.0-cp38-cp38-manylinux2014_aarch64.whl
('Pillow', '7.2.0', '3.8', 'bdist_wheel') Pillow-7.2.0-cp38-cp38-win32.whl
('Pillow', '7.2.0', '3.8', 'bdist_wheel') Pillow-7.2.0-cp38-cp38-win_amd64.whl
('Pillow', '7.2.0', '3.6', 'bdist_wheel') Pillow-7.2.0-pp36-pypy36_pp73-win32.whl
('Pillow', '7.2.0', '3.6', 'bdist_wheel') Pillow-7.2.0-pp36-pypy36_pp73-manylinux2010_x86_64.whl
```

I've not tested uploading files. Is there anything else needed to support PyPy3?